### PR TITLE
Use GCCVER only if defined

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,17 +39,15 @@ endif
 
 ifeq ($(LINUX),1)
 
-  # Standard macros
-  GCCVER =
-  # /usr/local/bin/
-  ifeq ($(GCCVER),10)
-    FC = gfortran-10
-    CC = gcc-10
-    LD = gcc-10
-  else
+  # Use a specific compiler version
+  ifeq ($(GCCVER),)
     FC = gfortran
     CC = gcc
     LD = gcc
+  else
+    FC = gfortran-$(GCCVER)
+    CC = gcc-$(GCCVER)
+    LD = gcc-$(GCCVER)
   endif
   LIBS = -Wl,--export-dynamic $(LGTK) -lm -lgfortran
 


### PR DESCRIPTION
Suggestion: right now, to use a specific version number, the user must edit the Makefile. With this change, `GCCVER` is used if it is defined. You can run:

- `make atomes GCCVER=12`, which will set the compilers to `gcc-12` etc.
- `make atomes` without version specified will set the compilers to `gcc` etc.