### PR TITLE
3 macOS-related fixes

### DIFF
--- a/src/curve/cedit.c
+++ b/src/curve/cedit.c
@@ -16,8 +16,8 @@ If not, see <https://www.gnu.org/licenses/> */
 #endif
 
 #include <gtk/gtk.h>
-#include <cairo/cairo.h>
-#include <cairo/cairo-pdf.h>
+#include <cairo.h>
+#include <cairo-pdf.h>
 #include <cairo-svg.h>
 #include <string.h>
 #include <stdlib.h>

--- a/src/curve/datab.c
+++ b/src/curve/datab.c
@@ -12,7 +12,7 @@ You should have received a copy of the GNU Affero General Public License along w
 If not, see <https://www.gnu.org/licenses/> */
 
 #include <gtk/gtk.h>
-#include <cairo/cairo.h>
+#include <cairo.h>
 #include <string.h>
 #include <stdlib.h>
 #include <math.h>

--- a/src/curve/draw.c
+++ b/src/curve/draw.c
@@ -15,7 +15,7 @@ If not, see <https://www.gnu.org/licenses/> */
 #include <gdk/gdk.h>
 #include <stdlib.h>
 #include <math.h>
-#include <cairo/cairo.h>
+#include <cairo.h>
 
 #include "global.h"
 #include "curve.h"

--- a/src/curve/frame.c
+++ b/src/curve/frame.c
@@ -13,7 +13,7 @@ If not, see <https://www.gnu.org/licenses/> */
 
 #include <stdlib.h>
 #include <gdk/gdk.h>
-#include <cairo/cairo.h>
+#include <cairo.h>
 
 #include "global.h"
 #include "curve.h"

--- a/src/curve/glyph.c
+++ b/src/curve/glyph.c
@@ -11,7 +11,7 @@ See the GNU General Public License for more details.
 You should have received a copy of the GNU Affero General Public License along with Atomes.
 If not, see <https://www.gnu.org/licenses/> */
 
-#include <cairo/cairo.h>
+#include <cairo.h>
 #include <math.h>
 
 #include "global.h"

--- a/src/curve/labels.c
+++ b/src/curve/labels.c
@@ -13,7 +13,7 @@ If not, see <https://www.gnu.org/licenses/> */
 
 #include <string.h>
 #include <math.h>
-#include <cairo/cairo.h>
+#include <cairo.h>
 #include <pango/pangocairo.h>
 
 #include "global.h"

--- a/src/curve/legend.c
+++ b/src/curve/legend.c
@@ -12,7 +12,7 @@ You should have received a copy of the GNU Affero General Public License along w
 If not, see <https://www.gnu.org/licenses/> */
 
 #include <stdlib.h>
-#include <cairo/cairo.h>
+#include <cairo.h>
 #include <pango/pangocairo.h>
 
 #include "global.h"

--- a/src/curve/show.c
+++ b/src/curve/show.c
@@ -12,9 +12,9 @@ You should have received a copy of the GNU Affero General Public License along w
 If not, see <https://www.gnu.org/licenses/> */
 
 #include <gtk/gtk.h>
-#include <cairo/cairo.h>
-#include <cairo/cairo-pdf.h>
-#include <cairo/cairo-ps.h>
+#include <cairo.h>
+#include <cairo-pdf.h>
+#include <cairo-ps.h>
 #include <cairo-svg.h>
 
 #include "global.h"

--- a/src/curve/tab-1.c
+++ b/src/curve/tab-1.c
@@ -16,8 +16,8 @@ If not, see <https://www.gnu.org/licenses/> */
 #endif
 
 #include <gtk/gtk.h>
-#include <cairo/cairo.h>
-#include <cairo/cairo-pdf.h>
+#include <cairo.h>
+#include <cairo-pdf.h>
 #include <cairo-svg.h>
 #include <string.h>
 #include <stdlib.h>

--- a/src/curve/tab-2.c
+++ b/src/curve/tab-2.c
@@ -16,8 +16,8 @@ If not, see <https://www.gnu.org/licenses/> */
 #endif
 
 #include <gtk/gtk.h>
-#include <cairo/cairo.h>
-#include <cairo/cairo-pdf.h>
+#include <cairo.h>
+#include <cairo-pdf.h>
 #include <cairo-svg.h>
 #include <string.h>
 #include <stdlib.h>

--- a/src/curve/tab-3.c
+++ b/src/curve/tab-3.c
@@ -16,8 +16,8 @@ If not, see <https://www.gnu.org/licenses/> */
 #endif
 
 #include <gtk/gtk.h>
-#include <cairo/cairo.h>
-#include <cairo/cairo-pdf.h>
+#include <cairo.h>
+#include <cairo-pdf.h>
 #include <cairo-svg.h>
 #include <string.h>
 #include <stdlib.h>

--- a/src/curve/tab-4.c
+++ b/src/curve/tab-4.c
@@ -16,8 +16,8 @@ If not, see <https://www.gnu.org/licenses/> */
 #endif
 
 #include <gtk/gtk.h>
-#include <cairo/cairo.h>
-#include <cairo/cairo-pdf.h>
+#include <cairo.h>
+#include <cairo-pdf.h>
 #include <cairo-svg.h>
 #include <string.h>
 #include <stdlib.h>

--- a/src/curve/title.c
+++ b/src/curve/title.c
@@ -12,7 +12,7 @@ You should have received a copy of the GNU Affero General Public License along w
 If not, see <https://www.gnu.org/licenses/> */
 
 #include <gtk/gtk.h>
-#include <cairo/cairo.h>
+#include <cairo.h>
 #include <pango/pangocairo.h>
 
 #include "global.h"

--- a/src/curve/w_curve.c
+++ b/src/curve/w_curve.c
@@ -15,7 +15,7 @@ If not, see <https://www.gnu.org/licenses/> */
 #include <math.h>
 #include <gtk/gtk.h>
 #include <gdk/gdk.h>
-#include <cairo/cairo.h>
+#include <cairo.h>
 
 #include "global.h"
 #include "callbacks.h"

--- a/src/curve/xaxis.c
+++ b/src/curve/xaxis.c
@@ -12,7 +12,7 @@ You should have received a copy of the GNU Affero General Public License along w
 If not, see <https://www.gnu.org/licenses/> */
 
 #include <math.h>
-#include <cairo/cairo.h>
+#include <cairo.h>
 
 #include "global.h"
 #include "curve.h"

--- a/src/curve/yaxis.c
+++ b/src/curve/yaxis.c
@@ -12,7 +12,7 @@ You should have received a copy of the GNU Affero General Public License along w
 If not, see <https://www.gnu.org/licenses/> */
 
 #include <math.h>
-#include <cairo/cairo.h>
+#include <cairo.h>
 
 #include "global.h"
 #include "curve.h"

--- a/src/global.h
+++ b/src/global.h
@@ -53,8 +53,12 @@ If not, see <https://www.gnu.org/licenses/> */
 #  define max(a,b) (a>=b?a:b)
 #  define min(a,b) (a<=b?a:b)
 #  include <epoxy/gl.h>
-#  include <GL/glu.h>
-#  include <epoxy/glx.h>
+#  ifdef __APPLE__
+#    include <OpenGL/glu.h>
+#  else
+#    include <GL/glu.h>
+#    include <epoxy/glx.h>
+#  endif
 #endif
 
 #include "math_3d.h"

--- a/src/lic/valid.c
+++ b/src/lic/valid.c
@@ -31,21 +31,12 @@ If not, see <https://www.gnu.org/licenses/> */
 #  include <netinet/in.h>
 #  include <arpa/inet.h>
 #  include <pwd.h>
-#endif
 
-#ifdef OSX
-#  include <sys/ioctl.h>
-#  include <sys/types.h>
-#  include <sys/socket.h>
-#  include <ifaddrs.h>
-#  include <netinet/in.h>
-#  include <arpa/inet.h>
-#  include <pwd.h>
-#endif
+// Linux only
+#  ifndef __APPLE__
+#    include <linux/if.h>
+#  endif
 
-// Linux
-#ifdef LINUX
-#  include <linux/if.h>
 #endif
 
 #ifdef AF_LINK
@@ -137,6 +128,8 @@ int mac_addr_sys ()
 
 #ifdef LINUX
 
+#  ifndef __APPLE__
+
 /* implementation for Linux using ioctl   */
 /* Only allows acces to active interfaces */
 /*
@@ -217,9 +210,7 @@ int mac_addr_sys ()
   }
   freeifaddrs (ifad);
 
-#endif
-
-#ifdef OSX
+#  else
 
 /* implementation for MacOSX using AF_LINK */
 /* Allows acces to all interfaces          */
@@ -256,6 +247,8 @@ int mac_addr_sys ()
     ifad_next = ifad_next -> ifa_next;
   }
   freeifaddrs (ifad);
+
+#  endif
 
 #endif
 


### PR DESCRIPTION
First commit: fix include paths to Cairo. According to all documentation I can find, the include path should be `<cairo.h>`, not `<cairo/cairo.h>`. I suspect this works on Linux anyway because `/usr/include` is the default include path, and so `/usr/include/cairo/cairo.h` happens to be available. On macOS, no such happy coincidence.

Second fix: macOS include path for `glu.h` is `OpenGL/glu.h`. Also, `epoxy/glx.h` does not exist on the macOS version (and does not appear to be necessary). I am guarding these fixes with the `__APPLE__` macro, which is always defined by compilers running on (or targeting) macOS.

Third fix: instead of duplicating `LINUX` and `OSX` code, which are the same everywhere, we make macOS a special case of the `LINUX` type (which would also work, for example, on BSD platforms). We guard the specific code with `__APPLE__` here again.