### PR TITLE
Makefile: do not pass --export-dynamic to the linker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ ifeq ($(LINUX),1)
     CC = gcc-$(GCCVER)
     LD = gcc-$(GCCVER)
   endif
-  LIBS = -Wl,--export-dynamic $(LGTK) -lm -lgfortran
+  LIBS = $(LGTK) -lm -lgfortran
 
   DOS = -DLINUX
   CPPFLAGS =  -DPACKAGE_DATA_DIR=\"\" \


### PR DESCRIPTION
I do not think it is necessary, and it is not an accepted linker flag on macOS.