### PR TITLE
Further macOS adjustments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,6 @@
 
 LINUX = 1
 WINDOWS = 0
-OSX = 0
 
 # The next line defines the GTK version !
 GTKV = 3

--- a/src/global.h
+++ b/src/global.h
@@ -39,7 +39,7 @@ If not, see <https://www.gnu.org/licenses/> */
 
 #include <pango/pangoft2.h>
 
-#ifdef OSX
+#ifdef MAC_INTEGRATION
 #  include <gtkosxapplication.h>
 #endif
 

--- a/src/gui/main.c
+++ b/src/gui/main.c
@@ -381,7 +381,7 @@ G_MODULE_EXPORT void run_program (GApplication * app, gpointer data)
   dfi[1]="w";
 #endif
 
-#ifdef OSX
+#ifdef MAC_INTEGRATION
   GtkosxApplication * ProgOSX;
   ProgOSX = g_object_new (GTKOSX_TYPE_APPLICATION, NULL);
   gtkosx_application_set_use_quartz_accelerators (ProgOSX, FALSE);
@@ -449,7 +449,7 @@ G_MODULE_EXPORT void run_program (GApplication * app, gpointer data)
     flist = NULL;
     silent_input = FALSE;
   }
-#ifdef OSX
+#ifdef MAC_INTEGRATION
   g_object_unref (ProgOSX);
 #endif
 }


### PR DESCRIPTION
The use of `gtkosxapplication.h` is limited to Gtk3 (where it was deprecated, see https://wiki.gnome.org/Projects/GTK/OSX/Integration). It should be guarded with the macro `MAC_INTEGRATION`, as per the documentation (https://jralls.github.io/gtk-mac-integration/GtkosxApplication.html); that macro is defined by `pkg-config` when necessary.

The remaining `OSX` variable in Makefile is not necessary. macOS is now a special case of `LINUX=1` (like FreeBSD and other Unix-like platforms), which is much easier for maintenance.